### PR TITLE
Detect open menus via LargeMap center

### DIFF
--- a/AuraTracker/AuraTracker.cs
+++ b/AuraTracker/AuraTracker.cs
@@ -132,7 +132,7 @@ namespace AuraTracker
             }
 
             const float menuThreshold = 0.00005f;
-            var delta = Math.Abs(currentCenter.Y - this.defaultLargeMapCenter.Value.Y);
+            var delta = Math.Abs(currentCenter.X - this.defaultLargeMapCenter.Value.X);
 
             if (delta >= menuThreshold)
             {

--- a/AuraTracker/AuraTracker.cs
+++ b/AuraTracker/AuraTracker.cs
@@ -24,6 +24,8 @@ namespace AuraTracker
         private readonly PanelRenderer panelRenderer = new();
         private readonly SettingsUiRenderer settingsRenderer = new(PluginVersion);
         private ActiveCoroutine onAreaChange;
+        private Vector2? defaultLargeMapCenter;
+        private bool isMenuOpen;
 
         private string SettingsPath => Path.Join(this.DllDirectory, "config", "AuraTracker.settings.json");
 
@@ -47,6 +49,8 @@ namespace AuraTracker
             }
 
             this.onAreaChange = CoroutineHandler.Start(OnAreaChange(), string.Empty, 0);
+            this.defaultLargeMapCenter = null;
+            this.isMenuOpen = false;
         }
 
         public override void OnDisable()
@@ -54,6 +58,8 @@ namespace AuraTracker
             this.onAreaChange?.Cancel();
             this.onAreaChange = null;
             this.dpsTracker.Reset();
+            this.defaultLargeMapCenter = null;
+            this.isMenuOpen = false;
         }
 
         public override void SaveSettings()
@@ -85,6 +91,11 @@ namespace AuraTracker
                 return;
             }
 
+            if (this.IsMenuOpen(inGame))
+            {
+                return;
+            }
+
             var overlaySize = new Vector2(Core.Overlay.Size.Width, Core.Overlay.Size.Height);
             var overlayCenter = overlaySize * 0.5f;
 
@@ -103,7 +114,35 @@ namespace AuraTracker
             {
                 yield return new Wait(RemoteEvents.AreaChanged);
                 this.dpsTracker.Reset();
+                this.defaultLargeMapCenter = null;
+                this.isMenuOpen = false;
             }
+        }
+
+        private bool IsMenuOpen(InGameState inGame)
+        {
+            var largeMap = inGame.GameUi.LargeMap;
+            var currentCenter = largeMap.Center;
+
+            if (!this.defaultLargeMapCenter.HasValue)
+            {
+                this.defaultLargeMapCenter = currentCenter;
+                this.isMenuOpen = false;
+                return false;
+            }
+
+            const float menuThreshold = 0.00005f;
+            var delta = Math.Abs(currentCenter.Y - this.defaultLargeMapCenter.Value.Y);
+
+            if (delta >= menuThreshold)
+            {
+                this.isMenuOpen = true;
+                return true;
+            }
+
+            this.isMenuOpen = false;
+            this.defaultLargeMapCenter = currentCenter;
+            return false;
         }
     }
 }


### PR DESCRIPTION
## Summary
- track the baseline LargeMap center when the plugin starts or the area changes
- detect menu openings by comparing the current LargeMap center against the baseline and skip rendering while menus are open

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d5e29808888331887f4f5ecdcf7195